### PR TITLE
Add without input to validates_address_format

### DIFF
--- a/lib/addressing/model.rb
+++ b/lib/addressing/model.rb
@@ -46,9 +46,12 @@ module Addressing
           if without&.is_a?(Regexp)
             fields.each do |field|
               address_field = address.send(field)
-              next if address_field.blank? || address_field.scan(without).empty?
+              next if address_field.blank?
 
-              errors.add(field, "should not contain any excluded characters")
+              scanned_chars = address_field.scan(without)
+              next if scanned_chars.empty?
+
+              errors.add(field, "should not contain '#{scanned_chars.uniq.join("', '")}'")
             end
           end
 

--- a/lib/addressing/model.rb
+++ b/lib/addressing/model.rb
@@ -3,7 +3,7 @@
 module Addressing
   module Model
     def validates_address_format(
-      fields: [:country_code, :administrative_area, :locality, :dependent_locality, :postal_code, :sorting_code, :address_line1, :address_line2, :organization, :given_name, :additional_name, :family_name, :locale], field_overrides: nil, **options)
+      fields: [:country_code, :administrative_area, :locality, :dependent_locality, :postal_code, :sorting_code, :address_line1, :address_line2, :organization, :given_name, :additional_name, :family_name, :locale], field_overrides: nil, without: nil, **options)
       fields = Array(fields)
       field_overrides ||= FieldOverrides.new({})
 
@@ -41,6 +41,15 @@ module Addressing
             next if address.send(unused_field).blank?
 
             errors.add(unused_field, "should be blank")
+          end
+
+          if without&.is_a?(Regexp)
+            fields.each do |field|
+              address_field = address.send(field)
+              next if address_field.blank? || address_field.scan(without).empty?
+
+              errors.add(field, "should not contain any excluded characters")
+            end
           end
 
           # Validate subdivisions.

--- a/test/model_test.rb
+++ b/test/model_test.rb
@@ -285,4 +285,24 @@ class ModelTest < Minitest::Test
     assert !address.valid?
     assert address.errors.key?(:administrative_area)
   end
+
+  def test_without_characters_in_address_fields
+    address_klass = Class.new(Address) do
+      validates_address_format without: /[@;&]/
+    end
+
+    address = address_klass.new(
+      country_code: "CN",
+      administrative_area: "Beijing Shi",
+      locality: "Xich&eng Qu",
+      address_line1: "Yiti@ao Lu",
+      postal_code: "123456",
+      given_name: "J;ohn",
+      family_name: "Smith"
+    )
+    assert !address.valid?
+    assert address.errors.key?(:locality)
+    assert address.errors.key?(:address_line1)
+    assert address.errors.key?(:given_name)
+  end
 end


### PR DESCRIPTION
Add a way to add a without: option with a regex to `validates_address_format` like in a rails `validates format: { without: ..}` way.