### PR TITLE
add missing % to generic address format

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.4"]
+        ruby: ["3.3", "3.2", "3.1"]
     name: Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.3", "3.2", "3.1"]
+        ruby: ["3.4"]
     name: Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v4

--- a/lib/addressing/address_format.rb
+++ b/lib/addressing/address_format.rb
@@ -42,7 +42,7 @@ module Addressing
 
       def generic_definition
         {
-          format: "%given_name %family_name\n%organization\n%address_line1\n%address_line2\n\%address_line3\n%locality",
+          format: "%given_name %family_name\n%organization\n%address_line1\n%address_line2\n%address_line3\n%locality",
           required_fields: [
             "address_line1", "locality"
           ],

--- a/lib/addressing/address_format.rb
+++ b/lib/addressing/address_format.rb
@@ -42,7 +42,7 @@ module Addressing
 
       def generic_definition
         {
-          format: "%given_name %family_name\n%organization\n%address_line1\n%address_line2\n\address_line3\n%locality",
+          format: "%given_name %family_name\n%organization\n%address_line1\n%address_line2\n\%address_line3\n%locality",
           required_fields: [
             "address_line1", "locality"
           ],

--- a/tasks/generate.rake
+++ b/tasks/generate.rake
@@ -84,7 +84,7 @@ def extract_base_definitions
   definitions = definitions_match[1].tr("'", '"').gsub("null", "nil").gsub(/\n\s+/, "\n          ").gsub(/,\s+$/, "\n        ")
 
   country_rb = File.read("lib/addressing/country.rb")
-  country_rb = country_rb.gsub(/@@base_definitions \|\|= \{[^\}]+\}/m, "@@base_definitions ||= {#{definitions}}")
+  country_rb = country_rb.gsub(/@@base_definitions \|\|= \{[^}]+\}/m, "@@base_definitions ||= {#{definitions}}")
 
   File.write("lib/addressing/country.rb", country_rb)
 end


### PR DESCRIPTION
When a country without an address format is used, the string "address_line3" is present in the formatted address.

```
address = Addressing::Address.new
address = address.with_country_code('GH')
                 .with_locality('Accra')
                 .with_address_line1('PO Box 123')
formatter = Addressing::PostalLabelFormatter.new
p formatter.format(address, origin_country: 'US')
"PO Box 123\n\address_line3\nACCRA\nGHANA"
```